### PR TITLE
fix legacy schema validation

### DIFF
--- a/nfelib/v4_00/leiauteNFe_sub.py
+++ b/nfelib/v4_00/leiauteNFe_sub.py
@@ -56,7 +56,7 @@ def schema_validation(inFilename, **kwargs):
         "nfe",
         "schemas",
         "v4_0",
-        "leiauteNFe_v4.00.xsd",
+        "nfe_v4.00.xsd",
     )
 
     xmlschema_doc = etree_.parse(parser_path)


### PR DESCRIPTION
o nome do arquivo do schema para a validação sempre foi esse. Eu que me equivoquei na hora de remanejar o caminho dos arquivos ontem.