### PR TITLE
[ADD] CTe Adapter

### DIFF
--- a/nfelib/nfe/ws/edoc_legacy.py
+++ b/nfelib/nfe/ws/edoc_legacy.py
@@ -12,6 +12,7 @@ try:
     from erpbrasil.edoc.edoc import DocumentoEletronico
     from erpbrasil.edoc.mde import MDe
     from erpbrasil.edoc.mdfe import MDFe
+    from erpbrasil.edoc.cte import CTe
     from erpbrasil.edoc.nfce import NFCe
     from erpbrasil.edoc.nfe import NFe
     from erpbrasil.edoc.resposta import RetornoSoap, analisar_retorno_raw
@@ -106,6 +107,10 @@ class NFCeAdapter(DocumentoElectronicoAdapter, NFCe):
 
 
 class MDeAdapter(DocumentoElectronicoAdapter, MDe):
+    pass
+
+
+class CTeAdapter(DocumentoElectronicoAdapter, CTe):
     pass
 
 


### PR DESCRIPTION
Adicionando o CTe adapter que importa o CTe presente no PR: https://github.com/erpbrasil/erpbrasil.edoc/pull/61. Vale ressaltar que estou abrindo em draft pois ainda faltam algumas mudanças que já estão prontas no PR do erpbrasil.edoc, mas que ainda não estão no repositório remoto. Assim que o CTe estiver no erpbrasil.edoc o CTe adapter deve funcionar como esperado.