### PR TITLE
Consultar situação da NF-e com objetos XSDATA

### DIFF
--- a/nfelib/nfe/ws/edoc_legacy.py
+++ b/nfelib/nfe/ws/edoc_legacy.py
@@ -5,6 +5,9 @@ from dataclasses import is_dataclass
 import base64
 from lxml import etree
 
+from nfelib.nfe.bindings.v4_0.cons_sit_nfe_v4_00 import ConsSitNfe
+from nfelib.nfe.bindings.v4_0.ret_cons_sit_nfe_v4_00 import RetConsSitNfe
+
 
 from erpbrasil.assinatura.assinatura import Assinatura
 
@@ -13,7 +16,7 @@ try:
     from erpbrasil.edoc.mde import MDe
     from erpbrasil.edoc.mdfe import MDFe
     from erpbrasil.edoc.nfce import NFCe
-    from erpbrasil.edoc.nfe import NFe
+    from erpbrasil.edoc.nfe import NFe, localizar_url, WS_NFE_CONSULTA
     from erpbrasil.edoc.resposta import RetornoSoap, analisar_retorno_raw
 
 
@@ -98,7 +101,24 @@ class DocumentoElectronicoAdapter(DocumentoEletronico):
 
 
 class NFeAdapter(DocumentoElectronicoAdapter, NFe):
-    pass
+    def consulta_documento(self, chave):
+        raiz = ConsSitNfe(
+            versao=self.versao,
+            tpAmb=self.ambiente,
+            xServ="CONSULTAR",
+            chNFe=chave,
+        )
+        return self._post(
+            raiz=raiz,
+            url=localizar_url(
+                WS_NFE_CONSULTA,
+                str(self.uf),
+                self.mod,
+                int(self.ambiente)
+            ),
+            operacao="nfeConsultaNF",
+            classe=RetConsSitNfe,
+        )
 
 
 class NFCeAdapter(DocumentoElectronicoAdapter, NFCe):


### PR DESCRIPTION
@rvalyi 

vou implementar o wizard para consultar o status da nfe no Odoo, porém o generateDS tá com um bug na classe do retorno do evento, pra não precisar mexer na parte legada do generateDS fiz um override da função `consulta_documento` do erpbrasil.edoc para trabalhar com objetos XSDATA tanto no envio quanto na respota.

