### PR TITLE
Correct Tcnfse class

### DIFF
--- a/nfelib/nfse/bindings/v1_0/tipos_complexos_v1_00.py
+++ b/nfelib/nfse/bindings/v1_0/tipos_complexos_v1_00.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
 from xsdata.models.datatype import XmlDate
+from nfelib import CommonMixin
 from nfelib.nfse.bindings.v1_0.tipos_simples_v1_00 import (
     TcobjetoLocacao,
     TsambGeradorNfse,
@@ -3092,7 +3093,7 @@ class TcinfNfse:
 
 
 @dataclass
-class Tcnfse:
+class Tcnfse(CommonMixin):
     class Meta:
         name = "TCNFSe"
 


### PR DESCRIPTION
As @dayvsonsales said on #85, `Nfse` class lacked basic common methods like those demonstrated in the README for "NFS-e padrão nacional":
```python
>>> # Ler uma NFS-e:
>>>> from nfelib.nfse.bindings.v1_0.nfse_v1_00 import Nfse
>>> nfse = Nfse.from_path("alguma_nfse.xml")
>>>
>>> # Serializar uma NFS-e:
>>> nfse.to_xml()
```

This pull request proposes updating Tcnfse to inherit basic methods from CommonMixin, enabling functionalities like `from_path()` and `to_xml()`.