### PR TITLE
add sign_xml and to_pdf utility methods

### DIFF
--- a/nfelib/__init__.py
+++ b/nfelib/__init__.py
@@ -124,8 +124,15 @@ class CommonMixin:
         xml_etree = etree.fromstring(xml.encode("utf-8"))
         return Assinatura(certificate).assina_xml2(xml_etree, doc_id)
 
-    def to_xml(self, pretty_print: bool = True, ns_map: Optional[Dict] = None) -> str:
-        """Serialize binding as an xml string."""
+    def to_xml(
+        self,
+        pretty_print: str = True,
+        ns_map: Optional[dict] = None,
+        pkcs12_data: Optional[bytes] = None,
+        pkcs12_password: Optional[str] = None,
+        doc_id: Optional[str] = None,
+    ) -> str:
+        """Serialize binding as xml. You can fill the signature params to sign it."""
         serializer = XmlSerializer(SerializerConfig(pretty_print=pretty_print))
         if ns_map is None:
             if self.namespace:
@@ -135,7 +142,10 @@ class CommonMixin:
             else:
                 package = self._get_package()
                 ns_map = {None: f"http://www.portalfiscal.inf.br/{package}"}
-        return serializer.render(obj=self, ns_map=ns_map)
+        xml = serializer.render(obj=self, ns_map=ns_map)
+        if doc_id:
+            return self.sign_xml(self, xml, pkcs12_data, pkcs12_password, doc_id=doc_id)
+        return xml
 
     def validate_xml(self, schema_path: Optional[str] = None) -> List:
         """Serialize binding as xml, validate it and return possible errors."""
@@ -145,7 +155,9 @@ class CommonMixin:
     # this was an attempt to keep the signature inside the
     # binding before serializing it again. But at the moment it fails
     # because xsdata will serialize the Signature elements with their namespaces.
-    # def sign(self, pkcs12_data: bytes = None, pkcs12_password: str = None, doc_id: str=None):
+    # def sign(self, pkcs12_data: bytes = None, pkcs12_password: str = None,
+    #     doc_id: str=None
+    # ) -> str:
     #     xml = self.to_xml(pretty_print=False)
     #     signed_xml = self.sign_xml(xml, pkcs12_data, pkcs12_password, element)
     #     nfe = self.from_xml(signed_xml)

--- a/nfelib/v4_00/leiauteNFe_sub.py
+++ b/nfelib/v4_00/leiauteNFe_sub.py
@@ -3,9 +3,22 @@
 import sys
 import os
 from lxml import etree as etree_
+import warnings
 
 sys.path.append(os.path.dirname(__file__))
 import retEnviNFe as supermod
+
+
+warnings.warn(
+    (
+        "These nfelib 1.x bindings (nfelib.v4_00; generated with GenerateDS) "
+        "are deprecated and will be removed after 01/06/2024. "
+        "\nYou should use the nfelib 2.x xsdata bindings in nfelib.nfe.bindings "
+        "instead.\nYou can learn about the migration process here: "
+        "https://github.com/akretion/nfelib/issues/59"
+    ),
+    DeprecationWarning,
+)
 
 
 def parsexml_(infile, parser=None, keep_signature=False, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ test =
     requests
     beautifulsoup4
     erpbrasil.assinatura
+    brazilfiscalreport
 
 [flake8]
 exclude = tests/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ test =
     tox
     requests
     beautifulsoup4
+    erpbrasil.assinatura
 
 [flake8]
 exclude = tests/*

--- a/tests/fingerprint.txt
+++ b/tests/fingerprint.txt
@@ -5,7 +5,7 @@
     ],
     "cte": [
         "https://www.cte.fazenda.gov.br/portal/listaConteudo.aspx?tipoConteudo=0xlG1bdBass=",
-        "d4721c910c48bedb1aabeca281a8d486"
+        "68c476b64cff31710cd6170170ae984c"
     ],
     "nfse": [
         "https://www.gov.br/nfse/pt-br/biblioteca/documentacao-tecnica",

--- a/tests/fingerprint.txt
+++ b/tests/fingerprint.txt
@@ -1,7 +1,7 @@
 {
     "nfe": [
         "https://www.nfe.fazenda.gov.br/portal/listaConteudo.aspx?tipoConteudo=BMPFMBoln3w=",
-        "d3959ba8780305f3120e8dafcd95ba95"
+        "35ac8b0887d877858edcedc5748e132c"
     ],
     "cte": [
         "https://www.cte.fazenda.gov.br/portal/listaConteudo.aspx?tipoConteudo=0xlG1bdBass=",

--- a/tests/nfe/test_nfe.py
+++ b/tests/nfe/test_nfe.py
@@ -67,6 +67,22 @@ class ClientTests(TestCase):
         # signed_xml2 = signed_nfe.to_xml(pretty_print=False)
         # self.assertEqual(signed_xml, signed_xml2)
 
+        pdf_bytes = nfe.to_pdf(
+            pkcs12_data=cert_data,
+            pkcs12_password=cert_password,
+            doc_id=nfe.NFe.infNFe.Id,
+        )
+        self.assertEqual(type(pdf_bytes), bytes)
+
+    def test_pdf(self):
+        path = os.path.join("nfelib", "nfe", "samples", "v4_0", "leiauteNFe")
+        filename = "42210775277525000178550030000266631762885493-procNFe.xml"
+        input_file = os.path.join(path, filename)
+        parser = XmlParser()
+        nfe = parser.from_path(Path(input_file))
+        pdf_bytes = nfe.to_pdf()
+        self.assertEqual(type(pdf_bytes), bytes)
+
     def test_in_out_leiauteNFe(self):
         path = os.path.join("nfelib", "nfe", "samples", "v4_0", "leiauteNFe")
         for filename in os.listdir(path):

--- a/tests/nfe/test_nfe.py
+++ b/tests/nfe/test_nfe.py
@@ -2,139 +2,134 @@
 
 import os
 from pathlib import Path
+from unittest import TestCase
 
-from xmldiff import main
-from xsdata.formats.dataclass.parsers import XmlParser
-from xsdata.formats.dataclass.serializers import XmlSerializer
-from xsdata.formats.dataclass.serializers.config import SerializerConfig
-
-from nfelib.nfe.bindings.v4_0 import leiaute_nfe_v4_00
 from nfelib.nfe.bindings.v4_0.leiaute_cons_sit_nfe_v4_00 import TconsSitNfe
 from nfelib.nfe.bindings.v4_0.leiaute_cons_stat_serv_v4_00 import TconsStatServ
 from nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00 import Tnfe
 from nfelib.nfe.bindings.v4_0.nfe_v4_00 import Nfe
 from nfelib.nfe_dist_dfe.bindings.v1_0.dist_dfe_int_v1_01 import DistDfeInt
 from nfelib.nfe_evento_generico.bindings.v1_0.leiaute_evento_v1_00 import TenvEvento
+from xmldiff import main
+from xsdata.formats.dataclass.parsers import XmlParser
+from xsdata.formats.dataclass.serializers import XmlSerializer
+from xsdata.formats.dataclass.serializers.config import SerializerConfig
 
 
-def test_patched_xsdata_for_ipi():
-    # o xsdata precisa de uma linha de patch para funcionar legal para a NFe
-    # (de forma simples/backward compatible no Odoo)
-    # uma alternativa seria usar a opção --compound-fields do xsdata mas
-    # deixaria o uso mais complexo no Odoo de forma desnecessaria. A gestão dos campos
-    # compostos/compound esta sendo retrabalhada no xsdata de qualquer forma.
-    # Enfim hoje o mais simples é aplicar um patch de uma linha no xsdata.
-    # Se vc instalar o pacote xsdata-odoo e fizer export XSD_SCHEMA=nfe,
-    # o xsdata-odoo aplica esse monkey patch para você.
-    # ver detalhes aqui: https://github.com/akretion/nfelib/issues/40
-    assert (
-        str(Tnfe.InfNfe.Det.Imposto().__annotations__["IPI"]).startswith(
-            "typing.Optional"
+class ClientTests(TestCase):
+    def test_patched_xsdata_for_ipi(self):
+        # o xsdata precisa de uma linha de patch para funcionar legal para a NFe
+        # (de forma simples/backward compatible no Odoo)
+        # uma alternativa seria usar a opção --compound-fields do xsdata mas
+        # deixaria o uso mais complexo no Odoo de forma desnecessaria. A gestão dos campos
+        # compostos/compound esta sendo retrabalhada no xsdata de qualquer forma.
+        # Enfim hoje o mais simples é aplicar um patch de uma linha no xsdata.
+        # Se vc instalar o pacote xsdata-odoo e fizer export XSD_SCHEMA=nfe,
+        # o xsdata-odoo aplica esse monkey patch para você.
+        # ver detalhes aqui: https://github.com/akretion/nfelib/issues/40
+        assert (
+            str(Tnfe.InfNfe.Det.Imposto().__annotations__["IPI"]).startswith(
+                "typing.Optional"
+            )
+            # Python < 3.9:
+            or str(Tnfe.InfNfe.Det.Imposto().__annotations__["IPI"])
+            == "typing.Union[nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00.Tipi, NoneType]"
         )
-        # Python < 3.9:
-        or str(Tnfe.InfNfe.Det.Imposto().__annotations__["IPI"])
-        == "typing.Union[nfelib.nfe.bindings.v4_0.leiaute_nfe_v4_00.Tipi, NoneType]"
-    )
 
+    def test_in_out_leiauteNFe(self):
+        path = os.path.join("nfelib", "nfe", "samples", "v4_0", "leiauteNFe")
+        for filename in os.listdir(path):
+            input_file = os.path.join(path, filename)
+            parser = XmlParser()
+            obj = parser.from_path(Path(input_file))
+            serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
+            xml = serializer.render(
+                obj=obj, ns_map={None: "http://www.portalfiscal.inf.br/nfe"}
+            )
+            # agora podemos trabalhar em cima do objeto e fazer operaçoes como:
+            #        obj.infNFe.emit.CNPJ
 
-def test_in_out_leiauteNFe():
-    path = os.path.join("nfelib", "nfe", "samples", "v4_0", "leiauteNFe")
-    for filename in os.listdir(path):
-        input_file = os.path.join(path, filename)
-        parser = XmlParser()
-        obj = parser.from_path(Path(input_file))
+            output_file = "tests/output_nfe_leiaute.xml"
+            with open(output_file, "w") as f:
+                f.write(xml)
+
+            diff = main.diff_files(input_file, output_file)
+            assert len(diff) == 0
+            if len(diff) != 0:
+                break
+
+    def test_in_out_leiauteInutNFe(self):
+        path = os.path.join("nfelib", "nfe", "samples", "v4_0", "leiauteInutNFe")
+        for filename in os.listdir(path):
+            input_file = os.path.join(path, filename)
+            parser = XmlParser()
+            obj = parser.from_path(Path(input_file))
+            serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
+            xml = serializer.render(
+                obj=obj, ns_map={None: "http://www.portalfiscal.inf.br/nfe"}
+            )
+
+            output_file = "tests/output_nfe_inut.xml"
+            with open(output_file, "w") as f:
+                f.write(xml)
+
+            diff = main.diff_files(input_file, output_file)
+            assert len(diff) == 0
+
+    def test_stat(self):
+        obj = TconsStatServ(
+            versao="4.00",
+            tpAmb="1",
+            cUF="12",
+            xServ="STATUS",
+        )
         serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
-        xml = serializer.render(
-            obj=obj, ns_map={None: "http://www.portalfiscal.inf.br/nfe"}
+        serializer.render(obj=obj)
+
+    def test_cons_sit(self):
+        obj = TconsSitNfe(
+            versao="4.00",
+            tpAmb="1",
+            xServ="CONSULTAR",
+            chNFe="NFe35180803102452000172550010000474641681223493",
         )
-        # agora podemos trabalhar em cima do objeto e fazer operaçoes como:
-        #        obj.infNFe.emit.CNPJ
-
-        output_file = "tests/output_nfe_leiaute.xml"
-        with open(output_file, "w") as f:
-            f.write(xml)
-
-        diff = main.diff_files(input_file, output_file)
-        assert len(diff) == 0
-        if len(diff) != 0:
-            break
-
-
-def test_in_out_leiauteInutNFe():
-    path = os.path.join("nfelib", "nfe", "samples", "v4_0", "leiauteInutNFe")
-    for filename in os.listdir(path):
-        input_file = os.path.join(path, filename)
-        parser = XmlParser()
-        obj = parser.from_path(Path(input_file))
         serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
-        xml = serializer.render(
-            obj=obj, ns_map={None: "http://www.portalfiscal.inf.br/nfe"}
+        serializer.render(obj=obj)
+
+    def test_distDFe(self):
+        obj = DistDfeInt(
+            versao="4.00",
+            tpAmb="1",
+            cUFAutor="SP",
+            distNSU=DistDfeInt.DistNsu(
+                ultNSU="35180803102452000172550010000474641681223493"
+            ),
+            consNSU=DistDfeInt.ConsNsu(
+                NSU="35180803102452000172550010000474641681223493"
+            ),
         )
+        serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
+        serializer.render(obj=obj)
 
-        output_file = "tests/output_nfe_inut.xml"
-        with open(output_file, "w") as f:
-            f.write(xml)
+    def test_evento_generico(self):
+        obj = TenvEvento(versao="1.00", idLote="42")
+        serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
+        serializer.render(obj=obj)
 
-        diff = main.diff_files(input_file, output_file)
-        assert len(diff) == 0
-
-
-def test_stat():
-    obj = TconsStatServ(
-        versao="4.00",
-        tpAmb="1",
-        cUF="12",
-        xServ="STATUS",
-    )
-    serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
-    xml = serializer.render(obj=obj)
-
-
-def test_cons_sit():
-    obj = TconsSitNfe(
-        versao="4.00",
-        tpAmb="1",
-        xServ="CONSULTAR",
-        chNFe="NFe35180803102452000172550010000474641681223493",
-    )
-    serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
-    xml = serializer.render(obj=obj)
-
-
-def test_distDFe():
-    obj = DistDfeInt(
-        versao="4.00",
-        tpAmb="1",
-        cUFAutor="SP",
-        distNSU=DistDfeInt.DistNsu(
-            ultNSU="35180803102452000172550010000474641681223493"
-        ),
-        consNSU=DistDfeInt.ConsNsu(NSU="35180803102452000172550010000474641681223493"),
-    )
-    serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
-    xml = serializer.render(obj=obj)
-
-
-def test_evento_generico():
-    obj = TenvEvento(versao="1.00", idLote="42")
-    serializer = XmlSerializer(config=SerializerConfig(pretty_print=True))
-    xml = serializer.render(obj=obj)
-
-
-def test_validator():
-    path = os.path.join(
-        "nfelib",
-        "nfe",
-        "samples",
-        "v4_0",
-        "leiauteNFe",
-        "NFe35200159594315000157550010000000012062777161.xml",
-    )
-    parser = XmlParser()
-    nfe_proc = parser.from_path(Path(path))
-    assert (
-        len(Nfe(infNFe=nfe_proc.NFe.infNFe).validate_xml()) == 3
-    )  # (we know this file has 3 schema errors)
+    def test_validator(self):
+        path = os.path.join(
+            "nfelib",
+            "nfe",
+            "samples",
+            "v4_0",
+            "leiauteNFe",
+            "NFe35200159594315000157550010000000012062777161.xml",
+        )
+        parser = XmlParser()
+        nfe_proc = parser.from_path(Path(path))
+        assert (
+            len(Nfe(infNFe=nfe_proc.NFe.infNFe).validate_xml()) == 3
+        )  # (we know this file has 3 schema errors)
 
 
 # def test_evento_cancelamento():


### PR DESCRIPTION
adição de helpers:

- sign_xml que é um metodo de class e usa o [erpbrasil.assinatura](https://github.com/erpbrasil/erpbrasil.assinatura)
- to_pdf que é um método nas instancias dos bindings raiz (como NFe) e serializa em pdf usando https://github.com/Engenere/BrazilFiscalReport ou https://github.com/erpbrasil/erpbrasil.edoc.pdf

o diff global talvez não é muito legível. Podem olhar commit por commit ou ver o arquivo final aqui https://github.com/akretion/nfelib/blob/add-sign-and-pdf/nfelib/__init__.py e ver que foi adicionado os helpers to_pdf e sign_xml.