### PR TITLE
feat: implement config in XmlParser from_xml

### DIFF
--- a/nfelib/__init__.py
+++ b/nfelib/__init__.py
@@ -22,9 +22,12 @@ class CommonMixin:
     namespace = None
 
     @classmethod
-    def from_xml(cls, xml: str) -> Any:
+    def from_xml(cls, xml: str, config=None) -> Any:
         """Parse xml and retun an instance of the class."""
-        return XmlParser().from_string(xml)
+        if config is None:
+            return XmlParser().from_string(xml)
+        else:
+            return XmlParser(config=config).from_string(xml)
 
     @classmethod
     def from_path(cls, path: str) -> Any:


### PR DESCRIPTION
Implementado um config pro XmlParser, afim de que possa passar como argumento as opções desejadas do parser, como por exemplo `ParserConfig(fail_on_unknown_properties=False, fail_on_unknown_attributes=False, fail_on_converter_warnings=False)` , desta forma caso exista alguma tag que ainda não esteja mapeada no xsd ele não vai dar erro, por não encontrar as propriedades.

Tal processo foi motivado pelo erro que tive com o xml em anexo, onde existe a tag gCred dentro do produto (det/prod), invalidando assim toda a leitura do xml, o que é inviável.

Para comprovar, faça um teste antes e depois executando o seguinte comando: 
```
xmlExample = ''
with open('data/xmls/xml_error.txt', 'r') as f:
    xmlExample = f.read()

NfeProc.from_xml(xmlExample)
```
Verá que antes da atualização vai dar erro `raise ParserError(f"Unknown property {self.meta.qname}:{qname}")
xsdata.exceptions.ParserError: Unknown property {http://www.portalfiscal.inf.br/nfe}Prod:{http://www.portalfiscal.inf.br/nfe}gCred`
Após atualização, se criar o ParserConfig conforme primeiro parágrafo e passar ele como argumento, será processado com sucesso.


XML Exemplo: [xml_error.txt](https://github.com/akretion/nfelib/files/15279262/xml_error.txt)
