### PR TITLE
[TEST] Add test for CTe IBSCBS xsdata patch

### DIFF
--- a/tests/cte/test_cte.py
+++ b/tests/cte/test_cte.py
@@ -10,9 +10,35 @@ from xsdata.formats.dataclass.serializers import XmlSerializer
 from xsdata.formats.dataclass.serializers.config import SerializerConfig
 
 from nfelib.cte.bindings import v4_0  # noqa: F401
+from nfelib.cte.bindings.v4_0.cte_tipos_basico_v4_00 import Tcte, TcteOs, TcteSimp
 
 
 class CTeTests(TestCase):
+    def test_patched_xsdata_for_ibscsb(self):
+        # see https://github.com/akretion/nfelib/pull/151
+        # IBSCBS should be TtribCte, not str
+        assert (
+            str(Tcte.InfCte.Imp().__annotations__["IBSCBS"])
+            == "typing.Optional[nfelib.cte.bindings.v4_0.dfe_tipos_basicos_v1_00.TtribCte]"
+            # Python < 3.9:
+            or str(Tcte.InfCte.Imp().__annotations__["IBSCBS"])
+            == "typing.Union[nfelib.cte.bindings.v4_0.dfe_tipos_basicos_v1_00.TtribCte, NoneType]"
+        )
+        assert (
+            str(TcteOs.InfCte.Imp().__annotations__["IBSCBS"])
+            == "typing.Optional[nfelib.cte.bindings.v4_0.dfe_tipos_basicos_v1_00.TtribCte]"
+            # Python < 3.9:
+            or str(TcteOs.InfCte.Imp().__annotations__["IBSCBS"])
+            == "typing.Union[nfelib.cte.bindings.v4_0.dfe_tipos_basicos_v1_00.TtribCte, NoneType]"
+        )
+        assert (
+            str(TcteSimp.InfCte.Imp().__annotations__["IBSCBS"])
+            == "typing.Optional[nfelib.cte.bindings.v4_0.dfe_tipos_basicos_v1_00.TtribCte]"
+            # Python < 3.9:
+            or str(TcteSimp.InfCte.Imp().__annotations__["IBSCBS"])
+            == "typing.Union[nfelib.cte.bindings.v4_0.dfe_tipos_basicos_v1_00.TtribCte, NoneType]"
+        )
+
     def test_in_out_cte(self):
         path = os.path.join("nfelib", "cte", "samples", "v4_0")
         for filename in os.listdir(path):


### PR DESCRIPTION
This PR adds a test to verify that the IBSCBS field in CTe bindings uses the correct TtribCte type instead of str.

## Changes
- Added test_patched_xsdata_for_ibscsb to tests/cte/test_cte.py
- Tests all three CTe document types: Tcte, TcteOs, and TcteSimp

## Context
This test ensures the namespace fix from PR #151 is properly applied. Similar to the existing NFe IBSCBS test (see tests/nfe/test_nfe.py).

## References
- Fixes: PR #151 (cte: fix TtribCte)
- Related: Issue #131 (Bindings quebrados para campos IBS/CBS)